### PR TITLE
[WIP] Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 scipy
 numba
 simpleaudio
+cython


### PR DESCRIPTION
Added `cython` to requirements.txt which is used in `synthesis.py`.

By the way, it is preferable to specify the version numbers. My requirements.txt generated by `pip freeze > requirements.txt` is below. It works fine when running `example/prosody.py`.

```
Cython==0.28.3
llvmlite==0.23.2
numba==0.38.1
numpy==1.14.5
scipy==1.1.0
simpleaudio==1.0.2
```

Can I commit this?